### PR TITLE
fix: null plate value and duplicate keys message

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -8,6 +8,7 @@ local MenuItemId1, MenuItemId2 = nil, nil
 local VehicleClassMap = {}
 
 local config = require 'config.client'
+local RenewedKeys = require 'config.shared'.RenewedKeys
 local Garages = require 'config.shared'.Garages
 local HouseGarages = require 'config.shared'.HouseGarages
 local ParkEnabled = false
@@ -708,7 +709,9 @@ function UpdateSpawnedVehicle(spawnedVehicle, vehicleInfo, heading, garage)
         SetAsMissionEntity(spawnedVehicle)
         ApplyVehicleDamage(spawnedVehicle, vehicleInfo)
         TriggerServerEvent('qb-garage:server:updateVehicleState', 0, vehicleInfo.plate, vehicleInfo.garage)
-        TriggerEvent("vehiclekeys:client:SetOwner", plate) -- There is really no other way to do this one since it's cliented...
+        if not RenewedKeys then
+            TriggerEvent("vehiclekeys:client:SetOwner", plate) -- There is really no other way to do this one since it's cliented...
+        end
     end
     SetEntityHeading(spawnedVehicle, heading)
     SetAsMissionEntity(spawnedVehicle)

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,6 +1,5 @@
 return {
     BrazzersFakeplate = false,
-    RenewedKeys = false, -- EXPERIMENTAL --
     StoreParkinglotAccuratly = true,  -- store the last parking lot in the DB, if set to true, make sure to apply / run patch1.sql, I recommend applying the tracking snippet for qb-phone from the ReadMe to the phone so you can track the vehicle to the exact parking lot
 
     addVehicleItems = false,

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -55,6 +55,8 @@
 return {
     Debug = true, -- To Debug the script
 
+    RenewedKeys = true, -- EXPERIMENTAL --
+
     HouseGarages = {}, -- DO NOT TOUCH!!
     Garages = {
         --[[

--- a/server/main.lua
+++ b/server/main.lua
@@ -134,7 +134,7 @@ lib.callback.register('qb-garage:server:spawnvehicle', function(source, vehInfo,
     local netId = NetworkGetNetworkIdFromEntity(veh)
     OutsideVehicles[plate] = {netID = netId, entity = veh}
 
-    SetVehicleNumberPlateText(veh, hasFakePlate)
+    SetVehicleNumberPlateText(veh, hasFakePlate or plate)
     if svConfig.RenewedKeys then
         exports['Renewed-Vehiclekeys']:addKey(source, hasFakePlate or plate)
     else

--- a/server/main.lua
+++ b/server/main.lua
@@ -4,6 +4,7 @@ local OutsideVehicles = {}
 local VehicleSpawnerVehicles = {}
 
 local svConfig = require 'config.server'
+local renewedKeys = require 'config.shared'.RenewedKeys
 local Garages = require 'config.shared'.Garages
 local HouseGarages = require 'config.shared'.HouseGarages
 
@@ -75,7 +76,7 @@ end)
 RegisterNetEvent("qb-garage:server:UpdateSpawnedVehicle", function(plate, value)
     VehicleSpawnerVehicles[plate] = value
 
-    if svConfig.RenewedKeys then
+    if renewedKeys then
         exports['Renewed-Vehiclekeys']:addKey(source, plate)
     else
         exports.qbx_vehiclekeys:GiveKeys(source, plate)
@@ -135,7 +136,7 @@ lib.callback.register('qb-garage:server:spawnvehicle', function(source, vehInfo,
     OutsideVehicles[plate] = {netID = netId, entity = veh}
 
     SetVehicleNumberPlateText(veh, hasFakePlate or plate)
-    if svConfig.RenewedKeys then
+    if renewedKeys then
         exports['Renewed-Vehiclekeys']:addKey(source, hasFakePlate or plate)
     else
         exports.qbx_vehiclekeys:GiveKeys(source, hasFakePlate or plate)
@@ -395,7 +396,7 @@ RegisterNetEvent('qb-garages:server:parkVehicle', function(source, plate)
     if vehicle then
         DeleteEntity(vehicle)
 
-        if svConfig.RenewedKeys then
+        if renewedKeys then
             exports.ox_inventory:RemoveItem(src, 'vehiclekey', 1, { plate = plate })
             exports['Renewed-Vehiclekeys']:removeKey(src, plate)
         end


### PR DESCRIPTION
Fixes issue where fake plate configuration is enabled and the vehicle doesn't have a fake plate causing the native to fail which prevents users from getting keys/fuel/etc.